### PR TITLE
Fix element names including a dot like "motion.div" were crashing in babel web

### DIFF
--- a/babel/web.js
+++ b/babel/web.js
@@ -6,7 +6,8 @@ const convertClassNameIntoTailwindStyles = ({ types: t }) => {
           let classNames;
           let existingStyles;
 
-          const firstCharOfName = path.node.name.name[0];
+          const name = path.node.name.name || path.node.name.object?.name;
+          const firstCharOfName = name[0];
 
           // Ignore elements that start in lower case
           if (


### PR DESCRIPTION
The web babel plugin was crashing because elements with dots in them (like framer-motion's `motion.div`) do not have a `name.name`. This gets the `object` name as a fallback.