### PR TITLE
Fix name of babel plugin in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Options can be provided via the babel config
 // babel.config.js
 module.exports = {
   plugins: [
-    ['tailwindcss-react-native', { platform: 'native' }]
+    ['tailwindcss-react-native/babel', { platform: 'native' }]
   ],
 }
 ```


### PR DESCRIPTION
I think this was a small typo?