### PR TITLE
Emit typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "0.0.22",
   "name": "tailwindcss-react-native",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "outDir": "dist",
     "strict": true,
     "target": "esnext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
The package was not emitting typings so consumers were seeing typescript errors when importing TailwindProvider.