### PR TITLE
fix: update quick start docs for NativeWind

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ Start writing code!
 import React from 'react';
 - import { StyleSheet, Text, View } from 'react-native';
 + import { Text, View } from 'react-native';
-import { TailwindProvider } from 'tailwindcss-react-native';
 
 export default function App() {
   return (


### PR DESCRIPTION
### What kind of change does this PR introduce?
Minor change to the last step of the quick start guide in the readme, which still contains an import from the depreciated <TailwindProvider />.

### What is the current behavior?
![image](https://user-images.githubusercontent.com/47414652/175819696-aad4eaf9-749f-4aeb-af07-fa9ff1c0e3b4.png)

### What is the new behavior?
![image](https://user-images.githubusercontent.com/47414652/175819731-adba7ff9-a873-4675-b603-871dbdae01f0.png)

